### PR TITLE
fix(travis): add ‘npm rebuild node-sass’ to .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ cache:
 install:
   - npm install -g yarn
   - yarn install
+  - npm rebuild node-sass
 
 script:
   - npm run deploy:dev


### PR DESCRIPTION
`npm rebuild node-sass` command fixed Travis build errors caused by Travis installing a wrong version of node-sass during the build process.